### PR TITLE
Adding key-value logs in Logger and device console logger

### DIFF
--- a/Logger.md
+++ b/Logger.md
@@ -13,6 +13,7 @@
 
 @objc(MJLogger) public protocol Logger {
   func log(_ level: LogLevel, tag: String, message: String)
+  func log(key: String, value: Any?)
 }
 ```
 
@@ -57,6 +58,13 @@ public protocol Logger {
     ///   - tag: An additional label to help categorise logs.
     ///   - message: The message to be logged.
     func log(level: LogLevel, tag: String?, message: String)
+
+    /// Logs a key-value pair
+    ///
+    /// - Parameters:
+    ///   - key: They key
+    ///   - value: The value
+    func log(key: String, value: Any?)
 }
 
 // MARK: - Default implementations
@@ -107,6 +115,14 @@ public class DeviceConsoleLogger: Logger {
             Swift.print("[\(levelStringRepresentation(of: level))], {\(message)}")
         }
     }    
+
+    public func log(key: String, value: Any?) {
+        if let value = value {
+            log(level: .info, tag: "KEY", message: "\(key): \(value)")
+        } else {
+            log(level: .info, tag: "KEY", message: "\(key): <nil>")
+        }
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
By adding a key-value log method in the `Logger` interface, we can now decouple Bugfender and other analytics providers from the implementation in our code.

As you know, to set a device key in Bugfender you must do:

```swift
Bugfender.setDeviceString(value, forKey: key)
```

This is a problem because there is no "instance" that can be mocked and we are hardcoding Bugfender references into our interactors, repositories or data sources.

With a key-value log method in `Logger`, we can abstract this and by having a `BugfenderLogger` implementation we can easily manage it within our dependency injection graph.

Note that I have already a swift implementation of it for TwoNav, but first I wanted to communicate here the new feature and once approved, I'll push it to Harmony-Swift (and other harmony implementations will be required to add it as well).

Thanks,